### PR TITLE
begin TwoWire object, not necessarily Wire

### DIFF
--- a/DFRobot_PAJ7620U2.cpp
+++ b/DFRobot_PAJ7620U2.cpp
@@ -21,7 +21,7 @@ DFRobot_PAJ7620U2::DFRobot_PAJ7620U2(TwoWire * pWire)
 int DFRobot_PAJ7620U2::begin(void)
 {
   uint16_t partid;
-  Wire.begin();
+  _pWire->begin();
   selectBank(eBank0);
   if(readReg(PAJ7620_ADDR_PART_ID_LOW, &partid, 2) == 0){
     DBG("bus data access error");


### PR DESCRIPTION
Hi,

I was having issue with using `DFRobot_PAJ7620U2 paj(&Wire2)` on Teensy3.5: where `paj.begin()` would hang.

Initializing the proper TwoWire object fixed it for me. I'm sorry but I didn't get a chance to test with the default i2C (SCL0; SDA0).

Qynn